### PR TITLE
IMEncode now returns NativeByteBuffer. Making it compatible with version v0.29.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,7 +82,9 @@ func getframes() {
 		}
 		frame_id++
 		gocv.Resize(img, &img, image.Point{}, float64(0.5), float64(0.5), 0)
-		frame, _ = gocv.IMEncode(".jpg", img)
+		frameBytes, _ := gocv.IMEncode(".jpg", img)
+		frame = frameBytes.GetBytes()
+		frameBytes.Close()
 
 	}
 }


### PR DESCRIPTION
In Version: v0.29.0,  `gocv.IMEncode(".jpg", img)` returns `gocv.NativeByteBuffer` and not `[]byte`.